### PR TITLE
Allow for custom serialization selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Add the [latest minified build](https://github.com/hunterloftis/cryo/tree/master
 
 Cryo has a very simple API that mimicks JSON:
 
-- `Cryo.stringify(item, [callback])`
-- `Cryo.parse(string, [callback])`
+- `Cryo.stringify(item, [callbacks])`
+- `Cryo.parse(string, [callbacks])`
 
 ```js
 var Cryo = require('cryo');
@@ -186,20 +186,20 @@ withCryo();                                         // Hello, world!
 
 ### Custom Types
 
-Cryo can allow you to stringify and parse custom types by using the optional callback argument. The callback for `stringify` is called before each item is stringified, allowing you to alter an object just before it's serialized. The callback for `parse` is called after each item is re-created, allowing you to alter an object just after it's de-serialized:
+Cryo can allow you to stringify and parse custom types by using the optional `callbacks` argument. The `prepare` for `stringify` is called before each item is stringified, allowing you to alter an object just before it's serialized. The `finalize` callback for `parse` is called after each item is re-created, allowing you to alter an object just after it's de-serialized:
 
 ```js
 function Person() {}
 var person = new Person();
 person.friends = [new Person()];
 
-var stringified = Cryo.stringify(person, function(obj) {
+var stringified = Cryo.stringify(person, { prepare: function(obj) {
   // store any object's constructor name under a variable called
   // __class__ which can later be be used to restore the object's
   // prototype.
   obj.__class__ = obj.constructor.name;
-});
-var parsed = Cryo.parse(stringified, function(obj) {
+}});
+var parsed = Cryo.parse(stringified, { finalize: function(obj) {
   // look for objects that define a __class__ and restore their
   // prototype by finding the class on the global window (you may need
   // to look elsewhere for the class).
@@ -207,10 +207,20 @@ var parsed = Cryo.parse(stringified, function(obj) {
     obj.__proto__ = window[obj.__class__].prototype;
     delete obj.__class__;
   }
-});
+}});
 
 parsed instanceof Person; // true
 parsed.friends[0] instanceof Person; // true
+```
+
+### Controlling Serialization
+
+By default, all *own* properties of an object will be serialized.  However, you can specify a custom `isSerializable` method as part of `callbacks` to pass to `stringify` to change this behavior.  By default it is defined as such:
+
+```js
+Cryo.stringify(data, { isSerializable: function(item, key) {
+  return item.hasOwnProperty(key);
+}});
 ```
 
 ### DOM

--- a/lib/cryo.js
+++ b/lib/cryo.js
@@ -30,9 +30,35 @@
     return typeof item;
   }
 
-  function stringify(item, callback) {
+  // Same as and copied from _.defaults
+  function defaults(obj) {
+    var length = arguments.length;
+    if (length < 2 || obj == null) return obj;
+    for (var index = 1; index < length; index++) {
+      var source = arguments[index],
+          keys = Object.keys(source),
+          l = keys.length;
+      for (var i = 0; i < l; i++) {
+        var key = keys[i];
+        if (obj[key] === void 0) obj[key] = source[key];
+      }
+    }
+    return obj;
+  };
+
+  function stringify(item, options) {
     var references = [];
-    var root = cloneWithReferences(item, references, callback);
+
+    // Backward compatibility with 0.0.6 that exepects `options` to be a callback.
+    options = typeof options === 'function' ? { prepare: options } : options;
+    options = defaults(options || {}, {
+      prepare: null,
+      isSerializable: function(item, key) {
+        return item.hasOwnProperty(key);
+      }
+    });
+
+    var root = cloneWithReferences(item, references, options);
 
     return JSON.stringify({
       root: root,
@@ -40,9 +66,9 @@
     });
   }
 
-  function cloneWithReferences(item, references, callback, savedItems) {
+  function cloneWithReferences(item, references, options, savedItems) {
     // invoke callback before any operations related to serializing the item
-    if (callback) { callback(item); }
+    if (options.prepare) { options.prepare(item); }
 
     savedItems = savedItems || [];
     var type = typeOf(item);
@@ -59,8 +85,8 @@
         }) - 1;
         savedItems[referenceIndex] = item;
         for (var key in item) {
-          if (item.hasOwnProperty(key)) {
-            clone[key] = cloneWithReferences(item[key], references, callback, savedItems);
+          if (options.isSerializable(item, key)) {
+            clone[key] = cloneWithReferences(item[key], references, options, savedItems);
           }
         }
       }
@@ -73,13 +99,17 @@
     return wrap(item);
   }
 
-  function parse(string, callback) {
+  function parse(string, options) {
     var json = JSON.parse(string);
 
-    return rebuildFromReferences(json.root, json.references, callback);
+    // Backward compatibility with 0.0.6 that exepects `options` to be a callback.
+    options = typeof options === 'function' ? { finalize: options } : options;
+    options = defaults(options || {}, { finalize: null });
+
+    return rebuildFromReferences(json.root, json.references, options);
   }
 
-  function rebuildFromReferences(item, references, callback, restoredItems) {
+  function rebuildFromReferences(item, references, options, restoredItems) {
     restoredItems = restoredItems || [];
     if (starts(item, REFERENCE_FLAG)) {
       var referenceIndex = parseInt(item.slice(REFERENCE_FLAG.length), 10);
@@ -89,18 +119,18 @@
         var contents = ref.contents;
         restoredItems[referenceIndex] = container;
         for (var key in contents) {
-          container[key] = rebuildFromReferences(contents[key], references, callback, restoredItems);
+          container[key] = rebuildFromReferences(contents[key], references, options, restoredItems);
         }
       }
 
       // invoke callback after all operations related to serializing the item
-      if (callback) { callback(restoredItems[referenceIndex]); }
+      if (options.finalize) { options.finalize(restoredItems[referenceIndex]); }
 
       return restoredItems[referenceIndex];
     }
 
     // invoke callback after all operations related to serializing the item
-    if (callback) { callback(item); }
+    if (options.finalize) { options.finalize(item); }
 
     return unwrap(item);
   }


### PR DESCRIPTION
Expands the callback argumentation of stringify and parse to allow for multiple different callbacks
to be sent to each (and is backward compatibile with 0.0.6).

Adds an `isSerializable` callback to `stringify` to allow users to customize the serialization
behavior.