### PR TITLE
feat: add support for class, arrows

### DIFF
--- a/lib/cryo.js
+++ b/lib/cryo.js
@@ -157,14 +157,7 @@
     if (typeOf(val) === 'string') {
       if (val === UNDEFINED_FLAG) return undefined;
       if (starts(val, FUNCTION_FLAG)) {
-        var fn = val.slice(FUNCTION_FLAG.length);
-        var argStart = fn.indexOf('(') + 1;
-        var argEnd = fn.indexOf(')', argStart);
-        var args = fn.slice(argStart, argEnd);
-        var bodyStart = fn.indexOf('{') + 1;
-        var bodyEnd = fn.lastIndexOf('}');
-        var body = fn.slice(bodyStart, bodyEnd);
-        return new Function(args, body);
+        return (new Function("return " + val.slice(FUNCTION_FLAG.length)))();
       }
       if (starts(val, DATE_FLAG)) {
         var dateNum = parseInt(val.slice(DATE_FLAG.length), 10);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cryo",
+  "name": "cryonic",
   "version": "0.0.6",
   "description": "Easily pickle/serialize/freeze/store and re-hydrate complex JavaScript objects (including Functions)",
   "keywords": [

--- a/test/function.test.js
+++ b/test/function.test.js
@@ -41,4 +41,33 @@ describe('Function', function() {
     assert.deepEqual(result1, result2);
   });
 
+  it('should hydrate an arrow function', function() {
+    var original = (from, to) => 'hello world from ' + from + ' to ' + to;
+    var stringified = Cryo.stringify(original);
+    var hydrated = Cryo.parse(stringified);
+
+    var result1 = original('Hunter', 'you');
+    var result2 = hydrated('Hunter', 'you');
+    assert.deepEqual(result1, result2);
+  });
+
+  it('should hydrate an arrow function without brackets', function() {
+    var original = from => 'hello world from ' + from;
+    var stringified = Cryo.stringify(original);
+    var hydrated = Cryo.parse(stringified);
+
+    var result1 = original('Hunter', 'you');
+    var result2 = hydrated('Hunter', 'you');
+    assert.deepEqual(result1, result2);
+  });
+
+  it('should hydrate a class', function() {
+    var original = class { foo(){} }
+    var stringified = Cryo.stringify(original);
+    var hydrated = Cryo.parse(stringified);
+
+    var result = new hydrated();
+    assert.isFunction(result.foo);
+  });
+
 });


### PR DESCRIPTION
This actually deletes the code that attempts to parse functions in favour of a simpler technique (originally used in [utilise/fn](https://github.com/utilise/fn/blob/master/index.js)) which means all the newer features like classes and arrow functions also work now. Tests added.